### PR TITLE
Fix a breoken link in the oidc readme

### DIFF
--- a/Documentation/connectors/oidc.md
+++ b/Documentation/connectors/oidc.md
@@ -2,7 +2,7 @@
 
 ## Overview
 
-Dex is able to use another OpenID Connect provider as an authentication source. When logging in, dex will redirect to the upstream provider and perform the necessary OAuth2 flows to determine the end users email, username, etc. More details on the OpenID Connect protocol can be found in [_An overview of OpenID Connect_][oidc-doc].
+Dex is able to use another OpenID Connect provider as an authentication source. When logging in, dex will redirect to the upstream provider and perform the necessary OAuth2 flows to determine the end users email, username, etc. More details on the OpenID Connect protocol can be found in [_An overview of OpenID Connect_](../openid-connect.md).
 
 Prominent examples of OpenID Connect providers include Google Accounts, Salesforce, and Azure AD v2 ([not v1][azure-ad-v1]).
 


### PR DESCRIPTION
Fixed a broken link to An overview of OpenID Connect